### PR TITLE
feat: add contact form and email API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ npm run dev
 - `NEXT_PUBLIC_SANITY_PROJECT_ID`
 - `NEXT_PUBLIC_SANITY_DATASET`
 
+### Contact
+
+The `/api/contact` route sends form submissions using [Resend](https://resend.com). Configure your `RESEND_API_KEY` and `CONTACT_TO` to enable email delivery.
+
 ## Deployment
 
 Deploy on [Vercel](https://vercel.com).

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,16 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { Resend } from 'resend'
+import { CONTACT_TO } from '../../../lib/constants'
 
-export async function POST(req: NextRequest) {
-  const { name, email, message } = await req.json()
+export async function POST(request: Request) {
+  const { name, email, message } = await request.json()
   try {
-    const resend = new Resend(process.env.RESEND_API_KEY)
+    const resend = new Resend(process.env.RESEND_API_KEY || '')
     await resend.emails.send({
-      from: 'portfolio@example.com',
-      to: process.env.CONTACT_TO ?? 'natul0636@natul.com',
-      subject: `Message from ${name}`,
+      from: 'Portfolio <onboarding@resend.dev>',
+      to: CONTACT_TO,
       replyTo: email,
-      text: message
+      subject: `New message from ${name}`,
+      text: String(message)
     })
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import Hero from '../components/Hero'
+import Contact from '../components/Contact'
 
 export default function HomePage() {
   return (
     <main>
       <Hero />
+      <Contact />
     </main>
   )
 }

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+
+export default function Contact() {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle')
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.currentTarget
+    const formData = new FormData(form)
+    setStatus('sending')
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: formData.get('name'),
+          email: formData.get('email'),
+          message: formData.get('message')
+        })
+      })
+      if (res.ok) {
+        form.reset()
+        setStatus('success')
+      } else {
+        setStatus('error')
+      }
+    } catch (err) {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <section id="contact" className="min-h-screen flex flex-col justify-center items-center px-4">
+      <h2 className="text-4xl font-bold mb-8">Get in touch</h2>
+      <form onSubmit={handleSubmit} className="w-full max-w-md space-y-4">
+        <input
+          type="text"
+          name="name"
+          required
+          placeholder="Name"
+          className="w-full p-3 bg-transparent border border-gray-700 focus:outline-none focus:border-white"
+        />
+        <input
+          type="email"
+          name="email"
+          required
+          placeholder="Email"
+          className="w-full p-3 bg-transparent border border-gray-700 focus:outline-none focus:border-white"
+        />
+        <textarea
+          name="message"
+          required
+          placeholder="Message"
+          className="w-full p-3 h-32 bg-transparent border border-gray-700 focus:outline-none focus:border-white"
+        />
+        <button
+          type="submit"
+          disabled={status === 'sending'}
+          className="w-full p-3 bg-white text-black font-medium hover:bg-gray-200 transition-colors disabled:opacity-50"
+        >
+          {status === 'sending' ? 'Sending...' : 'Send'}
+        </button>
+        {status === 'success' && (
+          <p className="text-green-400 text-sm">Message sent!</p>
+        )}
+        {status === 'error' && (
+          <p className="text-red-400 text-sm">Something went wrong. Please try again.</p>
+        )}
+      </form>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add contact section with client-side form
- send submissions through Resend via `/api/contact`
- document contact setup in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0514d03483318049ef4f59c36409